### PR TITLE
Parse argument for --language

### DIFF
--- a/scan
+++ b/scan
@@ -63,7 +63,7 @@ while [ $# -gt 0 ]; do
 
   --searchable|--ocr) SEARCHABLE=1 ;;
 
-  --language) LANGUAGE=$1 ;;
+  --language) shift; LANGUAGE=$1 ;;
 
   --skip-empty-pages) SKIP_EMPTY_PAGES=1 ;;
 


### PR DESCRIPTION
@rocketraman thank you so much for making this open source, this saves me hours of work!

This PR fixes a minor thing:
Before this commit, `scan --language deu` will exit with `Unknown argument: deu`
This commit fixes a forgotten "shift;" in order to parse the argument provided after `--language`.