### PR TITLE
Quote the device argument

### DIFF
--- a/scan
+++ b/scan
@@ -81,7 +81,7 @@ while [[ $# > 0 ]]; do
 
   -l|--outputlist) shift; USEARRAY=1; OUTPUTARR=(); OUTPUTARR+=("$1") ;;
 
-  -x|--device) shift; DEVICE=$1;;
+  -x|--device) shift; DEVICE="$1";;
 
   -xo|--driver-options) shift; DRIVER_OPTION=$1;;
 
@@ -245,7 +245,7 @@ fi;
 
 echo >&2 "Scanning..."
 #eval strace -f -o /tmp/scan-trace.txt scanadf -d $DEVICE $MAXPAGE $PGHEIGHT $PGWIDTH -S $SCRIPT --script-wait --resolution $RESOLUTION --mode $MODE $DESKEW $CROP $SOURCE -o scan-%04d
-eval scanadf -d "$DEVICE" $MAXPAGE $PGHEIGHT $PGWIDTH -S $SCRIPT --script-wait --resolution $RESOLUTION --mode $MODE $DESKEW $CROP $DRIVER_OPTION $SOURCE -o $TMP_DIR/scan-%04d
+eval scanadf -d \'"$DEVICE"\' $MAXPAGE $PGHEIGHT $PGWIDTH -S $SCRIPT --script-wait --resolution $RESOLUTION --mode $MODE $DESKEW $CROP $DRIVER_OPTION $SOURCE -o $TMP_DIR/scan-%04d
 
 shopt -s extglob nullglob
 pdffiles=($TMP_DIR/scan-[0-9]*.pdf)


### PR DESCRIPTION
Without doing so if the device includes a semicolon the following happens:

    % ./scan -x 'brother4:bus7;dev1'
    Scanning...
    scanadf: open of device brother4:bus7 failed: Invalid argument
    ./scan: line 248: dev1: command not found
    Found no scans.