### PR TITLE
Fix scanadf argument passing

### DIFF
--- a/scan
+++ b/scan
@@ -265,7 +265,13 @@ if [[ $MODE_HW_DEFAULT == 1 ]]; then
 else
   MODE="--mode '$MODE'"
 fi
-eval scanadf -d \'"$DEVICE"\' $MAXPAGE $PGHEIGHT $PGWIDTH -S $SCRIPT --script-wait --resolution $RESOLUTION $MODE $DESKEW $CROP $DRIVER_OPTION $SOURCE -o $TMP_DIR/scan-%04d
+if [[ $DESKEW == 0 ]]; then
+  DESKEW=
+fi
+if [[ $CROP == 0 ]]; then
+  CROP=
+fi
+eval scanadf -d \'"$DEVICE"\' $MAXPAGE $PGHEIGHT $PGWIDTH -S $SCRIPT --script-wait --resolution $RESOLUTION -o $TMP_DIR/scan-%04d $DESKEW $CROP $SOURCE $MODE $DRIVER_OPTION
 
 shopt -s extglob nullglob
 pdffiles=($TMP_DIR/scan-[0-9]*.pdf)


### PR DESCRIPTION
- When --crop and --deskew are not set, pass nothing instead of zeroes  as positional arguments
- Move driver option to the end, since its value is not quoted
- Move mode right before driver option to work around scanadf botching
  output file name in some cases

------

On master if I do not use --crop and --deskew, `scanadf` is invoked with zeroes as positional arguments. First I thought these were top/left coordinates, but now it seems this is actually an error in the script:

```
tinfoil% bash -x ./scan -x 'brother4:bus6;dev1' --no-default-height                           
...
++ scanadf -d 'brother4:bus6;dev1' -S /home/scan/sane-scan-pdf/scan_perpage --script-wait --resolution 300 --mode Lineart 0 0 -o /tmp/scan.a0aC0HwjF1/scan-%04d
```

The two zeroes after `Lineart` are, I believe, erroneous.

Additionally, my `scanadf` seems to produce bogus output file names (thus ignoring the `-o` option) when I request the gray mode and have `--mode` after `-o`:

```
tinfoil% scanadf -d 'brother4:bus6;dev1' --mode gray  0 0 -o here-please
scanadf: rounded value of br-x from 211.9 to 211.881
scanadf: rounded value of br-y from 355.6 to 355.567
Scanned document iffusion]
Scanned 1 pages
tinfoil% scanadf -d 'brother4:bus6;dev1' --mode gray   -o here-please 
scanadf: rounded value of br-x from 211.9 to 211.881
scanadf: rounded value of br-y from 355.6 to 355.567
Scanned document or Diffusion]
Scanned 1 pages
tinfoil% scanadf -d 'brother4:bus6;dev1' -o here-please --mode gray   
scanadf: rounded value of br-x from 211.9 to 211.881
scanadf: rounded value of br-y from 355.6 to 355.567
Scanned document here-please
Scanned 1 pages
```

To deal with this, I moved `--mode` to the end of the command line.

However I also believe the driver option isn't quoted, meaning *this* option must actually be the last one, therefore I put `--mode` right before the driver option.