### PR TITLE
Helper script for emulating a duplex scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ and see below for how to retrieve the list of modes that your system understands
 
 ### Scripts
 
-*emulate_duplex_scan.sh* Emulate a duplex scan. Scan front and backs to separate documents, then use the script to collate into one without the need to reverse the order of pages.
+*emulate_duplex_scan.sh*
+Emulate a duplex scan. Scan odd and even pages of the document to separate documents, then use the script to collate into one document without the need to reverse the order of pages.
 
 
 ### Helpful Commands

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Installation](https://github.com/rocketraman/sane-scan-pdf/wiki/Dependencies-Ins
 * sem (via gnu-parallels, to constrain resource usage during page processing -- install this if you have a fast scanner)
 * bc (for whitepage detection percentage calculations)
 * xdg-open (for opening scan after completion)
+* qpdf (for collating two scan documents)
 
 ## Getting Started
 
@@ -165,6 +166,11 @@ you are receiving an error about `--page-width`/`--page-height` being
 unrecognized options, try the `--no-default-size` option. If you receive an
 error about the `--mode` value being invalid, try `--mode-hw-default`
 and see below for how to retrieve the list of modes that your system understands.
+
+### Scripts
+
+*emulate_duplex_scan.sh* Emulate a duplex scan. Scan front and backs to separate documents, then use the script to collate into one without the need to reverse the order of pages.
+
 
 ### Helpful Commands
 

--- a/scripts/emulate_duplex_scan.sh
+++ b/scripts/emulate_duplex_scan.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+help()
+{
+   echo "$(basename $0) PDF-src-odd-pages PDF-src-even-pages PDF-destfile"
+}
+
+ARGC=$#
+
+file_A=$1
+file_B=$2
+output_file=$3
+
+if [ $ARGC -ne 3 ]; then
+   help
+   exit 1
+fi
+
+qpdf --collate --empty --pages "$file_A" "$file_B" z-1 -- "$output_file"
+


### PR DESCRIPTION
First idea of the script was to separate each document and then unite it, smth similar to this:
```
pdfseparate "$file_A" $TMP_DIR/scan-separated-%d-A.pdf
pdfseparate "$file_B" $TMP_DIR/scan-separated-%d-B.pdf

pdfunite $TMP_DIR/scan-separated-*-*.pdf "$output_file"
```

The script assumed odd pages and even pages are scanned in ascending order.
So before a scan one would need to change the order of all the pages to get a proper scan document... but we can scan the sheets in descending order and then reverse using some tools.

After some research on PDF tools that are able to split/merge/reverse the order of the pages in the PDF... the "script" boils down to one command:
 ```
 qpdf --collate --empty --pages odd.pdf even.pdf z-1 -- output.pdf
 ```

I wrapped the command into a helper script and added a short README mention.


Fixes https://github.com/rocketraman/sane-scan-pdf/issues/40